### PR TITLE
Remove depreciated Twig_Filter_method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,8 @@
         "psr-0": {
             "Jasny\\Twig": "src/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="./vendor/autoload.php">
+    <testsuites>
+        <testsuite name="The project's test suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Jasny/Twig/ArrayExtension.php
+++ b/src/Jasny/Twig/ArrayExtension.php
@@ -26,11 +26,11 @@ class ArrayExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'sum' => new \Twig_Filter_Method($this, 'sum'),
-            'product' => new \Twig_Filter_Method($this, 'product'),
-            'values' => new \Twig_Filter_Method($this, 'values'),
-            'as_array' => new \Twig_Filter_Method($this, 'asArray'),
-            'html_attr' => new \Twig_Filter_Method($this, 'HTMLAttributes'),
+            'sum' => new \Twig_SimpleFilter('sum', array($this, 'sum')),
+            'product' => new \Twig_SimpleFilter('product', array($this, 'product')),
+            'values' => new \Twig_SimpleFilter('values', array($this, 'values')),
+            'as_array' => new \Twig_SimpleFilter('as_array', array($this, 'asArray')),
+            'html_attr' => new \Twig_SimpleFilter('html_attr', array($this, 'HTMLAttributes')),
         );
     }
     

--- a/src/Jasny/Twig/DateExtension.php
+++ b/src/Jasny/Twig/DateExtension.php
@@ -35,11 +35,11 @@ class DateExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'localdate' => new \Twig_Filter_Method($this, 'localDate'),
-            'localtime' => new \Twig_Filter_Method($this, 'localTime'),
-            'localdatetime' => new \Twig_Filter_Method($this, 'localDateTime'),
-            'duration' => new \Twig_Filter_Method($this, 'duration'),
-            'age' => new \Twig_Filter_Method($this, 'age'),
+            'localdate' => new \Twig_SimpleFilter('localdate', array($this, 'localDate')),
+            'localtime' => new \Twig_SimpleFilter('localtime', array($this, 'localTime')),
+            'localdatetime' => new \Twig_SimpleFilter('localdatetime', array($this, 'localDateTime')),
+            'duration' => new \Twig_SimpleFilter('duration', array($this, 'duration')),
+            'age' => new \Twig_SimpleFilter('age', array($this, 'age')),
         );
     }
 

--- a/src/Jasny/Twig/PcreExtension.php
+++ b/src/Jasny/Twig/PcreExtension.php
@@ -25,14 +25,14 @@ class PcreExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'preg_quote' => new \Twig_Filter_Method($this, 'quote'),
-            'preg_match' => new \Twig_Filter_Method($this, 'match'),
-            'preg_get' => new \Twig_Filter_Method($this, 'get'),
-            'preg_get_all' => new \Twig_Filter_Method($this, 'getAll'),
-            'preg_grep' => new \Twig_Filter_Method($this, 'grep'),
-            'preg_replace' => new \Twig_Filter_Method($this, 'replace'),
-            'preg_filter' => new \Twig_Filter_Method($this, 'filter'),
-            'preg_split' => new \Twig_Filter_Method($this, 'split'),
+            'preg_quote' => new \Twig_SimpleFilter('preg_quote', array($this, 'quote')),
+            'preg_match' => new \Twig_SimpleFilter('preg_match', array($this, 'match')),
+            'preg_get' => new \Twig_SimpleFilter('preg_get', array($this, 'get')),
+            'preg_get_all' => new \Twig_SimpleFilter('preg_get_all', array($this, 'getAll')),
+            'preg_grep' => new \Twig_SimpleFilter('preg_grep', array($this, 'grep')),
+            'preg_replace' => new \Twig_SimpleFilter('preg_replace', array($this, 'replace')),
+            'preg_filter' => new \Twig_SimpleFilter('preg_filter', array($this, 'filter')),
+            'preg_split' => new \Twig_SimpleFilter('preg_splig', array($this, 'split')),
         );
     }
 

--- a/src/Jasny/Twig/TextExtension.php
+++ b/src/Jasny/Twig/TextExtension.php
@@ -15,11 +15,11 @@ class TextExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'paragraph' => new \Twig_Filter_Method($this, 'paragraph', array('pre_escape' => 'html', 'is_safe' => array('html'))),
-            'line' => new \Twig_Filter_Method($this, 'line'),
-            'less' => new \Twig_Filter_Method($this, 'less', array('pre_escape' => 'html', 'is_safe' => array('html'))),
-            'truncate' => new \Twig_Filter_Method($this, 'truncate', array('pre_escape' => 'html', 'is_safe' => array('html'))),
-            'linkify' => new \Twig_Filter_Method($this, 'linkify', array('pre_escape' => 'html', 'is_safe' => array('html'))),
+            'paragraph' => new \Twig_SimpleFilter('paragraph', array($this, 'paragraph'), array('pre_escape' => 'html', 'is_safe' => array('html'))),
+            'line' => new \Twig_SimpleFilter('line', array($this, 'line')),
+            'less' => new \Twig_SimpleFilter('less', array($this, 'less'), array('pre_escape' => 'html', 'is_safe' => array('html'))),
+            'truncate' => new \Twig_SimpleFilter('truncate', array($this, 'truncate'), array('pre_escape' => 'html', 'is_safe' => array('html'))),
+            'linkify' => new \Twig_SimpleFilter('linkify', array($this, 'linkify'), array('pre_escape' => 'html', 'is_safe' => array('html'))),
         );
     }
 

--- a/tests/Jasny/Twig/ArrayExtensionTest.php
+++ b/tests/Jasny/Twig/ArrayExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jasny\Twig;
+
+use Jasny\Twig\ArrayExtension;
+
+class ArrayExtensionTest extends PHPUnit_Framework_TestCase {
+
+    private function buildEnv($template) {
+        $loader = new Twig_Loader_Array(array(
+            'template' => $template,
+        ));
+        $twig = new Twig_Environment($loader);
+        $twig->addExtension(new ArrayExtension());
+        return $twig;
+    }
+    
+    private function process($template, $data = array()) {
+        $twig = $this->buildEnv($template);
+        $result = $twig->render('template', $data);
+        return $result;
+    }
+    
+    private function check($expected, $template, $data = array()) {
+        $result = $this->process($template, $data);
+        $this->assertEquals($expected, $result);
+    }
+    
+    public function testSum() {
+        $data = array(1, 2, 3, 4);
+        $this->check(10, '{{ data|sum() }}', array('data' => $data));
+    }
+
+    public function testProduct() {
+        $data = array(1, 2, 3, 4);
+        $this->check(24, '{{ data|product() }}', array('data' => $data));
+    }
+
+    public function testValues() {
+        $data = array(1, 2, 3);
+        $this->check('1-2-3-', '{% for v in data|values() %}{{v}}-{% endfor %}', array('data' => $data));
+    }
+
+    public function testHtmlAttr() {
+        $data = array('href' => 'foo.html', 'class' => 'big small');
+        $this->check('href="foo.html" class="big small"', '{{ data|html_attr|raw }}', array('data' => $data));
+    }
+
+    
+}

--- a/tests/Jasny/Twig/DateExtensionTest.php
+++ b/tests/Jasny/Twig/DateExtensionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jasny\Twig;
+
+use Jasny\Twig\DateExtension;
+
+class DateExtensionTest extends PHPUnit_Framework_TestCase {
+
+    public static function setUpBeforeClass() {
+        parent::setUpBeforeClass();
+        Locale::setDefault("en_CA");
+    }
+    
+    private function buildEnv($template) {
+        $loader = new Twig_Loader_Array(array(
+            'template' => $template,
+        ));
+        $twig = new Twig_Environment($loader);
+        $twig->addExtension(new DateExtension());
+        return $twig;
+    }
+    
+    private function process($template, $data = array()) {
+        $twig = $this->buildEnv($template);
+        $result = $twig->render('template', $data);
+        return $result;
+    }
+    
+    private function check($expected, $template) {
+        $result = $this->process($template);
+        $this->assertEquals($expected, $result);
+    }
+    
+    public function testLocalDate() {
+        $this->check('9/20/2015', "{{ '20-09-2015'|localdate() }}");
+    }
+
+    public function testLocalDateLong() {
+        $this->check('September 20, 2015', "{{ '20-09-2015'|localdate('long') }}");
+    }
+
+    public function testLocalDateShort() {
+        $this->check('9/20/15', "{{ '20-09-2015'|localdate('short') }}");
+    }
+
+    public function testLocalTime() {
+        $this->check('11:14 PM', "{{ '23:14:12'|localtime() }}");
+    }
+
+    public function testLocalTimeLong() {
+        $this->check('11:14:12 PM PDT', "{{ '23:14:12'|localtime('long') }}");
+    }
+
+    public function testLocalTimeShort() {
+        $this->check('11:14 PM', "{{ '23:14:12'|localtime('short') }}");
+    }
+
+}

--- a/tests/Jasny/Twig/PcreExtensionTest.php
+++ b/tests/Jasny/Twig/PcreExtensionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Jasny\Twig;
+
+use Jasny\Twig\PcreExtension;
+
+class PcreExtensionTest extends PHPUnit_Framework_TestCase {
+
+    private function buildEnv($template) {
+        $loader = new Twig_Loader_Array(array(
+            'template' => $template,
+        ));
+        $twig = new Twig_Environment($loader);
+        $twig->addExtension(new PcreExtension());
+        return $twig;
+    }
+    
+    private function process($template, $data = array()) {
+        $twig = $this->buildEnv($template);
+        $result = $twig->render('template', $data);
+        return $result;
+    }
+    
+    private function check($expected, $template) {
+        $result = $this->process($template);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testQuote() {
+        $this->check('foo\(\)', '{{ "foo()"|preg_quote }}');
+    }
+    
+    public function testQuoteDelimiter() {
+        $this->check('foo\@bar', '{{ "foo@bar"|preg_quote("@") }}');
+    }
+    
+    public function testPregMatch() {
+        $this->check('YES', '{% if "foo"|preg_match("/oo/") %}YES{% else %}NO{% endif %}');
+    }
+
+    public function testPregMatchNo() {
+        $this->check('NO', '{% if "fod"|preg_match("/oo/") %}YES{% else %}NO{% endif %}');
+    }
+
+    /**
+     * @expectedException Twig_Error_Runtime
+     */
+    public function testPregMatchError() {
+        $this->check('NO', '{% if "fod"|preg_match("/o//o/") %}YES{% else %}NO{% endif %}');
+    }
+    
+    public function testPregGet() {
+        $this->check('d', '{{ "food"|preg_get("/oo(.)/", 1) }}');
+    }
+    
+    public function testPregGetDefault() {
+        $this->check('ood', '{{ "food"|preg_get("/oo(.)/") }}');
+    }
+    
+}

--- a/tests/Jasny/Twig/TextExtensionTest.php
+++ b/tests/Jasny/Twig/TextExtensionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Jasny\Twig;
+
+use Jasny\Twig\TextExtension;
+
+class TextExtensionTest extends PHPUnit_Framework_TestCase {
+
+    private function buildEnv($template) {
+        $loader = new Twig_Loader_Array(array(
+            'template' => $template,
+        ));
+        $twig = new Twig_Environment($loader);
+        $twig->addExtension(new TextExtension());
+        return $twig;
+    }
+    
+    private function process($template, $data = array()) {
+        $twig = $this->buildEnv($template);
+        $result = $twig->render('template', $data);
+        return $result;
+    }
+    
+    private function check($expected, $template) {
+        $result = $this->process($template);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testQuote() {
+        $this->check("<p>foo<br>\nbar</p>", "{{ 'foo\nbar'|paragraph() }}");
+    }
+    
+    public function testLine() {
+        $this->check("bar", "{{ 'foo\nbar\nbaz'|line(2) }}");
+    }
+    
+    public function testLess() {
+        $this->check("foo..", "{{ 'fooXbarXbaz'|less('..', 'X') }}");
+    }
+    
+    public function testTruncate() {
+        $this->check("foo ..", "{{ 'foo bar baz'|truncate(4, '..') }}");
+    }
+    
+}


### PR DESCRIPTION
Use Twig_SimpleFilter instead of the depreciated Twig_Filter_Method class. 

Also add a test suite to make sure the filters continue to work, and add
phpunit as a composer --dev requirement.
