### PR TITLE
Added support for twig 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,18 @@ addons:
         packages:
             - language-pack-nl
 php:
-  - 5.6
   - 7.0
   - 7.1
+  - 7.4
 
 branches:
   only:
     - master
-    
+
 install:
   - composer install
   - wget https://scrutinizer-ci.com/ocular.phar -O "$HOME/ocular.phar"
-  
+
 script:
   - vendor/bin/phpunit --coverage-clover cache/logs/clover.xml
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=7.0.0 | >=5.6.0",
-        "twig/twig": "^2.0 | ^1.12"
+        "twig/twig": "^2.0 | ^3.0"
     },
     "suggest": {
         "ext-intl": "Required for the use of the LocalDate Twig extension",

--- a/src/ArrayExtension.php
+++ b/src/ArrayExtension.php
@@ -2,14 +2,17 @@
 
 namespace Jasny\Twig;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
 /**
  * Expose PHP's array functions to Twig
  */
-class ArrayExtension extends \Twig_Extension
+class ArrayExtension extends AbstractExtension
 {
     /**
      * Return extension name
-     * 
+     *
      * @return string
      */
     public function getName()
@@ -24,18 +27,18 @@ class ArrayExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('sum', [$this, 'sum']),
-            new \Twig_SimpleFilter('product', [$this, 'product']),
-            new \Twig_SimpleFilter('values', [$this, 'values']),
-            new \Twig_SimpleFilter('as_array', [$this, 'asArray']),
-            new \Twig_SimpleFilter('html_attr', [$this, 'htmlAttributes']),
+            new TwigFilter('sum', [$this, 'sum']),
+            new TwigFilter('product', [$this, 'product']),
+            new TwigFilter('values', [$this, 'values']),
+            new TwigFilter('as_array', [$this, 'asArray']),
+            new TwigFilter('html_attr', [$this, 'htmlAttributes']),
         ];
     }
-    
+
 
     /**
      * Calculate the sum of values in an array
-     * 
+     *
      * @param array $array
      * @return int
      */
@@ -43,10 +46,10 @@ class ArrayExtension extends \Twig_Extension
     {
         return isset($array) ? array_sum((array)$array) : null;
     }
-    
+
     /**
      * Calculate the product of values in an array
-     * 
+     *
      * @param array $array
      * @return int
      */
@@ -54,10 +57,10 @@ class ArrayExtension extends \Twig_Extension
     {
         return isset($array) ? array_product((array)$array) : null;
     }
-    
+
     /**
      * Return all the values of an array or object
-     * 
+     *
      * @param array|object $array
      * @return array
      */
@@ -65,10 +68,10 @@ class ArrayExtension extends \Twig_Extension
     {
         return isset($array) ? array_values((array)$array) : null;
     }
-    
+
     /**
      * Cast value to an array
-     * 
+     *
      * @param object|mixed $value
      * @return array
      */
@@ -76,10 +79,10 @@ class ArrayExtension extends \Twig_Extension
     {
         return is_object($value) ? get_object_vars($value) : (array)$value;
     }
-    
+
     /**
      * Cast an array to an HTML attribute string
-     * 
+     *
      * @param mixed $array
      * @return string
      */
@@ -88,20 +91,20 @@ class ArrayExtension extends \Twig_Extension
         if (!isset($array)) {
             return null;
         }
-       
+
         $str = "";
         foreach ($array as $key => $value) {
             if (!isset($value) || $value === false) {
                 continue;
             }
-            
+
             if ($value === true) {
                 $value = $key;
             }
-            
+
             $str .= ' ' . $key . '="' . addcslashes($value, '"') . '"';
         }
-        
+
         return trim($str);
     }
 }

--- a/src/DateExtension.php
+++ b/src/DateExtension.php
@@ -2,10 +2,13 @@
 
 namespace Jasny\Twig;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
 /**
  * Format a date based on the current locale in Twig
  */
-class DateExtension extends \Twig_Extension
+class DateExtension extends AbstractExtension
 {
     /**
      * Class constructor
@@ -17,10 +20,10 @@ class DateExtension extends \Twig_Extension
         }
     }
 
-    
+
     /**
      * Return extension name
-     * 
+     *
      * @return string
      */
     public function getName()
@@ -30,23 +33,23 @@ class DateExtension extends \Twig_Extension
 
     /**
      * Callback for Twig to get all the filters.
-     * 
-     * @return \Twig_SimpleFilter[]
+     *
+     * @return \Twig\TwigFilter[]
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('localdate', [$this, 'localDate']),
-            new \Twig_SimpleFilter('localtime', [$this, 'localTime']),
-            new \Twig_SimpleFilter('localdatetime', [$this, 'localDateTime']),
-            new \Twig_SimpleFilter('duration', [$this, 'duration']),
-            new \Twig_SimpleFilter('age', [$this, 'age']),
+            new TwigFilter('localdate', [$this, 'localDate']),
+            new TwigFilter('localtime', [$this, 'localTime']),
+            new TwigFilter('localdatetime', [$this, 'localDateTime']),
+            new TwigFilter('duration', [$this, 'duration']),
+            new TwigFilter('age', [$this, 'age']),
         ];
     }
 
     /**
      * Turn a value into a DateTime object
-     * 
+     *
      * @param string|int|\DateTime $date
      * @return \DateTime
      */
@@ -55,13 +58,13 @@ class DateExtension extends \Twig_Extension
         if (!$date instanceof \DateTime) {
             $date = is_int($date) ? \DateTime::createFromFormat('U', $date) : new \DateTime((string)$date);
         }
-        
+
         return $date;
     }
-    
+
     /**
      * Get configured intl date formatter.
-     * 
+     *
      * @param string|null $dateFormat
      * @param string|null $timeFormat
      * @param string      $calendar
@@ -73,19 +76,19 @@ class DateExtension extends \Twig_Extension
         $timetype = isset($timeFormat) ? $this->getFormat($timeFormat) : null;
 
         $calendarConst = $calendar === 'traditional' ? \IntlDateFormatter::TRADITIONAL : \IntlDateFormatter::GREGORIAN;
-        
+
         $pattern = $this->getDateTimePattern(
             isset($datetype) ? $datetype : $dateFormat,
             isset($timetype) ? $timetype : $timeFormat,
             $calendarConst
         );
-        
+
         return new \IntlDateFormatter(\Locale::getDefault(), $datetype, $timetype, null, $calendarConst, $pattern);
     }
-    
+
     /**
      * Format the date/time value as a string based on the current locale
-     * 
+     *
      * @param string|false $format  'short', 'medium', 'long', 'full', 'none' or false
      * @return int|null
      */
@@ -94,7 +97,7 @@ class DateExtension extends \Twig_Extension
         if ($format === false) {
             $format = 'none';
         }
-        
+
         $types = [
             'none' => \IntlDateFormatter::NONE,
             'short' => \IntlDateFormatter::SHORT,
@@ -102,13 +105,13 @@ class DateExtension extends \Twig_Extension
             'long' => \IntlDateFormatter::LONG,
             'full' => \IntlDateFormatter::FULL
         ];
-        
+
         return isset($types[$format]) ? $types[$format] : null;
     }
-    
+
     /**
      * Get the date/time pattern.
-     * 
+     *
      * @param int|string $datetype
      * @param int|string $timetype
      * @param int        $calendar
@@ -119,17 +122,17 @@ class DateExtension extends \Twig_Extension
         if (is_int($datetype) && is_int($timetype)) {
             return null;
         }
-        
+
         return $this->getDatePattern(
             isset($datetype) ? $datetype : \IntlDateFormatter::SHORT,
             isset($timetype) ? $timetype : \IntlDateFormatter::SHORT,
             $calendar
         );
     }
-    
+
     /**
      * Get the formatter to create a date and/or time pattern
-     * 
+     *
      * @param int|string $datetype
      * @param int|string $timetype
      * @param int        $calendar
@@ -145,11 +148,11 @@ class DateExtension extends \Twig_Extension
             $calendar
         );
     }
-    
+
     /**
      * Get the date and/or time pattern
      * Default date pattern is short date pattern with 4 digit year.
-     * 
+     *
      * @param int|string $datetype
      * @param int|string $timetype
      * @param int        $calendar
@@ -160,9 +163,9 @@ class DateExtension extends \Twig_Extension
         $createPattern =
             (is_int($datetype) && $datetype !== \IntlDateFormatter::NONE) ||
             (is_int($timetype) && $timetype !== \IntlDateFormatter::NONE);
-        
+
         $pattern = $createPattern ? $this->getDatePatternFormatter($datetype, $timetype, $calendar)->getPattern() : '';
-        
+
         return trim(
             (is_string($datetype) ? $datetype . ' ' : '') .
             preg_replace('/\byy?\b/', 'yyyy', $pattern) .
@@ -172,7 +175,7 @@ class DateExtension extends \Twig_Extension
 
     /**
      * Format the date and/or time value as a string based on the current locale
-     * 
+     *
      * @param \DateTime|int|string $value
      * @param string               $dateFormat  null, 'short', 'medium', 'long', 'full' or pattern
      * @param string               $timeFormat  null, 'short', 'medium', 'long', 'full' or pattern
@@ -184,16 +187,16 @@ class DateExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         $date = $this->valueToDateTime($value);
         $formatter = $this->getDateFormatter($dateFormat, $timeFormat, $calendar);
-        
+
         return $formatter->format($date->getTimestamp());
     }
 
     /**
      * Format the date value as a string based on the current locale
-     * 
+     *
      * @param DateTime|int|string $date
      * @param string              $format    null, 'short', 'medium', 'long', 'full' or pattern
      * @param string              $calendar  'gregorian' or 'traditional'
@@ -203,10 +206,10 @@ class DateExtension extends \Twig_Extension
     {
         return $this->formatLocal($date, $format, false, $calendar);
     }
-    
+
     /**
      * Format the time value as a string based on the current locale
-     * 
+     *
      * @param DateTime|int|string $date
      * @param string              $format    'short', 'medium', 'long', 'full' or pattern
      * @param string              $calendar  'gregorian' or 'traditional'
@@ -219,7 +222,7 @@ class DateExtension extends \Twig_Extension
 
     /**
      * Format the date/time value as a string based on the current locale
-     * 
+     *
      * @param DateTime|int|string $date
      * @param string              $format    date format, pattern or ['date'=>format, 'time'=>format)
      * @param string              $calendar  'gregorian' or 'traditional'
@@ -234,14 +237,14 @@ class DateExtension extends \Twig_Extension
             $formatDate = $format;
             $formatTime = false;
         }
-        
+
         return $this->formatLocal($date, $formatDate, $formatTime, $calendar);
     }
-    
+
 
     /**
      * Split duration into seconds, minutes, hours, days, weeks and years.
-     * 
+     *
      * @param int $seconds
      * @return array
      */
@@ -250,42 +253,42 @@ class DateExtension extends \Twig_Extension
         if ($max < 1 || $seconds < 60) {
             return [$seconds];
         }
-        
+
         $minutes = floor($seconds / 60);
         $seconds = $seconds % 60;
         if ($max < 2 || $minutes < 60) {
             return [$seconds, $minutes];
         }
-        
+
         $hours = floor($minutes / 60);
         $minutes = $minutes % 60;
         if ($max < 3 || $hours < 24) {
             return [$seconds, $minutes, $hours];
         }
-        
+
         $days = floor($hours / 24);
         $hours = $hours % 24;
         if ($max < 4 || $days < 7) {
-            return [$seconds, $minutes, $hours, $days]; 
+            return [$seconds, $minutes, $hours, $days];
         }
-        
+
         $weeks = floor($days / 7);
         $days = $days % 7;
         if ($max < 5 || $weeks < 52) {
             return [$seconds, $minutes, $hours, $days, $weeks];
         }
-        
+
         $years = floor($weeks / 52);
         $weeks = $weeks % 52;
         return [$seconds, $minutes, $hours, $days, $weeks, $years];
     }
-    
+
     /**
      * Calculate duration from seconds.
      * One year is seen as exactly 52 weeks.
-     * 
+     *
      * Use null to skip a unit.
-     * 
+     *
      * @param int    $value     Time in seconds
      * @param array  $units     Time units (seconds, minutes, hours, days, weeks, years)
      * @param string $separator
@@ -296,41 +299,41 @@ class DateExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         list($seconds, $minutes, $hours, $days, $weeks, $years) =
             $this->splitDuration($value, count($units) - 1) + array_fill(0, 6, null);
-        
+
         $duration = '';
         if (isset($years) && isset($units[5])) {
             $duration .= $separator . $years . $units[5];
         }
-        
+
         if (isset($weeks) && isset($units[4])) {
             $duration .= $separator . $weeks . $units[4];
         }
-        
+
         if (isset($days) && isset($units[3])) {
             $duration .= $separator . $days . $units[3];
         }
-        
+
         if (isset($hours) && isset($units[2])) {
             $duration .= $separator . $hours . $units[2];
         }
-        
+
         if (isset($minutes) && isset($units[1])) {
             $duration .= $separator . $minutes . $units[1];
         }
-        
+
         if (isset($seconds) && isset($units[0])) {
             $duration .= $separator . $seconds . $units[0];
         }
-        
+
         return trim($duration, $separator);
     }
 
     /**
      * Get the age (in years) based on a date.
-     * 
+     *
      * @param DateTime|string $value
      * @return int
      */
@@ -339,9 +342,9 @@ class DateExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         $date = $this->valueToDateTime($value);
-        
+
         return $date->diff(new \DateTime())->format('%y');
     }
 }

--- a/src/PcreExtension.php
+++ b/src/PcreExtension.php
@@ -2,12 +2,16 @@
 
 namespace Jasny\Twig;
 
+use Twig\Error\RuntimeError;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
 /**
  * Expose the PCRE functions to Twig.
- * 
+ *
  * @see http://php.net/manual/en/book.pcre.php
  */
-class PcreExtension extends \Twig_Extension
+class PcreExtension extends AbstractExtension
 {
     /**
      * Class constructor
@@ -21,7 +25,7 @@ class PcreExtension extends \Twig_Extension
 
     /**
      * Return extension name
-     * 
+     *
      * @return string
      */
     public function getName()
@@ -35,21 +39,21 @@ class PcreExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('preg_quote', [$this, 'quote']),
-            new \Twig_SimpleFilter('preg_match', [$this, 'match']),
-            new \Twig_SimpleFilter('preg_get', [$this, 'get']),
-            new \Twig_SimpleFilter('preg_get_all', [$this, 'getAll']),
-            new \Twig_SimpleFilter('preg_grep', [$this, 'grep']),
-            new \Twig_SimpleFilter('preg_replace', [$this, 'replace']),
-            new \Twig_SimpleFilter('preg_filter', [$this, 'filter']),
-            new \Twig_SimpleFilter('preg_split', [$this, 'split']),
+            new TwigFilter('preg_quote', [$this, 'quote']),
+            new TwigFilter('preg_match', [$this, 'match']),
+            new TwigFilter('preg_get', [$this, 'get']),
+            new TwigFilter('preg_get_all', [$this, 'getAll']),
+            new TwigFilter('preg_grep', [$this, 'grep']),
+            new TwigFilter('preg_replace', [$this, 'replace']),
+            new TwigFilter('preg_filter', [$this, 'filter']),
+            new TwigFilter('preg_split', [$this, 'split']),
         ];
     }
 
-    
+
     /**
      * Check that the regex doesn't use the eval modifier
-     * 
+     *
      * @param string $pattern
      * @throws \LogicException
      */
@@ -57,16 +61,16 @@ class PcreExtension extends \Twig_Extension
     {
         $pos = strrpos($pattern, $pattern[0]);
         $modifiers = substr($pattern, $pos + 1);
-        
+
         if (strpos($modifiers, 'e') !== false) {
-            throw new \Twig_Error_Runtime("Using the eval modifier for regular expressions is not allowed");
+            throw new RuntimeError("Using the eval modifier for regular expressions is not allowed");
         }
     }
-    
+
 
     /**
      * Quote regular expression characters.
-     * 
+     *
      * @param string $value
      * @param string $delimiter
      * @return string
@@ -76,13 +80,13 @@ class PcreExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         return preg_quote($value, $delimiter);
     }
 
     /**
      * Perform a regular expression match.
-     * 
+     *
      * @param string $value
      * @param string $pattern
      * @return boolean
@@ -92,13 +96,13 @@ class PcreExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         return preg_match($pattern, $value);
     }
 
     /**
      * Perform a regular expression match and return a matched group.
-     * 
+     *
      * @param string $value
      * @param string $pattern
      * @return string
@@ -108,13 +112,13 @@ class PcreExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         return preg_match($pattern, $value, $matches) && isset($matches[$group]) ? $matches[$group] : null;
     }
 
     /**
      * Perform a regular expression match and return the group for all matches.
-     * 
+     *
      * @param string $value
      * @param string $pattern
      * @return array
@@ -124,14 +128,14 @@ class PcreExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         return preg_match_all($pattern, $value, $matches, PREG_PATTERN_ORDER) && isset($matches[$group])
             ? $matches[$group] : [];
     }
 
     /**
      * Perform a regular expression match and return an array of entries that match the pattern
-     * 
+     *
      * @param array  $values
      * @param string $pattern
      * @param string $flags    Optional 'invert' to return entries that do not match the given pattern.
@@ -142,17 +146,17 @@ class PcreExtension extends \Twig_Extension
         if (!isset($values)) {
             return null;
         }
-        
+
         if (is_string($flags)) {
             $flags = $flags === 'invert' ? PREG_GREP_INVERT : 0;
         }
-        
+
         return preg_grep($pattern, $values, $flags);
     }
 
     /**
      * Perform a regular expression search and replace.
-     * 
+     *
      * @param string $value
      * @param string $pattern
      * @param string $replacement
@@ -162,17 +166,17 @@ class PcreExtension extends \Twig_Extension
     public function replace($value, $pattern, $replacement = '', $limit = -1)
     {
         $this->assertNoEval($pattern);
-        
+
         if (!isset($value)) {
             return null;
         }
-        
+
         return preg_replace($pattern, $replacement, $value, $limit);
     }
 
     /**
      * Perform a regular expression search and replace, returning only matched subjects.
-     * 
+     *
      * @param string $value
      * @param string $pattern
      * @param string $replacement
@@ -182,17 +186,17 @@ class PcreExtension extends \Twig_Extension
     public function filter($value, $pattern, $replacement = '', $limit = -1)
     {
         $this->assertNoEval($pattern);
-        
+
         if (!isset($value)) {
             return null;
         }
-        
+
         return preg_filter($pattern, $replacement, $value, $limit);
     }
 
     /**
      * Split text into an array using a regular expression.
-     * 
+     *
      * @param string $value
      * @param string $pattern
      * @return array
@@ -202,7 +206,7 @@ class PcreExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         return preg_split($pattern, $value);
     }
 }

--- a/src/TextExtension.php
+++ b/src/TextExtension.php
@@ -2,38 +2,41 @@
 
 namespace Jasny\Twig;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
 /**
  * Text functions for Twig.
  */
-class TextExtension extends \Twig_Extension
+class TextExtension extends AbstractExtension
 {
     /**
      * Return extension name
-     * 
+     *
      * @return string
      */
     public function getName()
     {
         return 'jasny/text';
     }
-    
+
     /**
      * {@inheritdoc}
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('paragraph', [$this, 'paragraph'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
-            new \Twig_SimpleFilter('line', [$this, 'line']),
-            new \Twig_SimpleFilter('less', [$this, 'less'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
-            new \Twig_SimpleFilter('truncate', [$this, 'truncate'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
-            new \Twig_SimpleFilter('linkify', [$this, 'linkify'], ['pre_escape' => 'html', 'is_safe' => ['html']])
+            new TwigFilter('paragraph', [$this, 'paragraph'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
+            new TwigFilter('line', [$this, 'line']),
+            new TwigFilter('less', [$this, 'less'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
+            new TwigFilter('truncate', [$this, 'truncate'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
+            new TwigFilter('linkify', [$this, 'linkify'], ['pre_escape' => 'html', 'is_safe' => ['html']])
         ];
     }
 
     /**
      * Add paragraph and line breaks to text.
-     * 
+     *
      * @param string $value
      * @return string
      */
@@ -42,15 +45,15 @@ class TextExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         return '<p>' . preg_replace(['~\n(\s*)\n\s*~', '~(?<!</p>)\n\s*~'], ["</p>\n\$1<p>", "<br>\n"], trim($value)) .
             '</p>';
     }
 
     /**
      * Get a single line
-     * 
-     * @param string $value 
+     *
+     * @param string $value
      * @param int    $line   Line number (starts at 1)
      * @return string
      */
@@ -59,15 +62,15 @@ class TextExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         $lines = explode("\n", $value);
-        
+
         return isset($lines[$line - 1]) ? $lines[$line - 1] : null;
     }
-    
+
     /**
      * Cut of text on a pagebreak.
-     * 
+     *
      * @param string $value
      * @param string $replace
      * @param string $break
@@ -78,14 +81,14 @@ class TextExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         $pos = stripos($value, $break);
         return $pos === false ? $value : substr($value, 0, $pos) . $replace;
     }
 
     /**
      * Cut of text if it's to long.
-     * 
+     *
      * @param string $value
      * @param int    $length
      * @param string $replace
@@ -96,13 +99,13 @@ class TextExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         return strlen($value) <= $length ? $value : substr($value, 0, $length - strlen($replace)) . $replace;
     }
-    
+
     /**
      * Linkify a HTTP(S) link.
-     * 
+     *
      * @param string $protocol  'http' or 'https'
      * @param string $text
      * @param array  $links     OUTPUT
@@ -115,19 +118,19 @@ class TextExtension extends \Twig_Extension
         $regexp = $mode != 'all'
             ? '~(?:(https?)://([^\s<>]+)|(?<!\w@)\b(www\.[^\s<>]+?\.[^\s<>]+))(?<![\.,:;\?!\'"\|])~i'
             : '~(?:(https?)://([^\s<>]+)|(?<!\w@)\b([^\s<>@]+?\.[^\s<>]+)(?<![\.,:]))~i';
-        
+
         return preg_replace_callback($regexp, function ($match) use ($protocol, &$links, $attr) {
             if ($match[1]) $protocol = $match[1];
             $link = $match[2] ?: $match[3];
-            
+
             return '<' . array_push($links, '<a' . $attr . ' href="' . $protocol . '://' . $link . '">'
                 . rtrim($link, '/') . '</a>') . '>';
         }, $text);
     }
-    
+
     /**
      * Linkify a mail link.
-     * 
+     *
      * @param string $text
      * @param array  $links     OUTPUT
      * @param string $attr
@@ -136,17 +139,17 @@ class TextExtension extends \Twig_Extension
     protected function linkifyMail($text, array &$links, $attr)
     {
         $regexp = '~([^\s<>]+?@[^\s<>]+?\.[^\s<>]+)(?<![\.,:;\?!\'"\|])~';
-        
+
         return preg_replace_callback($regexp, function ($match) use (&$links, $attr) {
             return '<' . array_push($links, '<a' . $attr . ' href="mailto:' . $match[1] . '">' . $match[1] . '</a>')
                 . '>';
         }, $text);
     }
-    
-    
+
+
     /**
      * Linkify a link.
-     * 
+     *
      * @param string $protocol
      * @param string $text
      * @param array  $links     OUTPUT
@@ -159,20 +162,20 @@ class TextExtension extends \Twig_Extension
         if (strpos($protocol, ':') === false) {
             $protocol .= in_array($protocol, ['ftp', 'tftp', 'ssh', 'scp']) ? '://' : ':';
         }
-        
+
         $regexp = $mode != 'all'
             ? '~' . preg_quote($protocol, '~') . '([^\s<>]+)(?<![\.,:;\?!\'"\|])~i'
             : '~([^\s<>]+)(?<![\.,:])~i';
-        
+
         return preg_replace_callback($regexp, function ($match) use ($protocol, &$links, $attr) {
             return '<' . array_push($links, '<a' . $attr . ' href="' . $protocol . $match[1] . '">' . $match[1]
                 . '</a>') . '>';
         }, $text);
     }
-    
+
     /**
      * Turn all URLs in clickable links.
-     * 
+     *
      * @param string $value
      * @param array  $protocols   'http'/'https', 'mail' and also 'ftp', 'scp', 'tel', etc
      * @param array  $attributes  HTML attributes for the link
@@ -184,20 +187,20 @@ class TextExtension extends \Twig_Extension
         if (!isset($value)) {
             return null;
         }
-        
+
         // Link attributes
         $attr = '';
         foreach ($attributes as $key => $val) {
             $attr .= ' ' . $key . '="' . htmlentities($val) . '"';
         }
-        
+
         $links = [];
-        
+
         // Extract existing links and tags
         $text = preg_replace_callback('~(<a .*?>.*?</a>|<.*?>)~i', function ($match) use (&$links) {
             return '<' . array_push($links, $match[1]) . '>';
         }, $value);
-        
+
         // Extract text links for each protocol
         foreach ((array)$protocols as $protocol) {
             switch ($protocol) {
@@ -207,7 +210,7 @@ class TextExtension extends \Twig_Extension
                 default:        $text = $this->linkifyOther($protocol, $text, $links, $attr, $mode); break;
             }
         }
-        
+
         // Insert all link
         return preg_replace_callback('/<(\d+)>/', function ($match) use (&$links) {
             return $links[$match[1] - 1];

--- a/tests/DateExtensionTest.php
+++ b/tests/DateExtensionTest.php
@@ -17,7 +17,7 @@ class DateExtensionTest extends \PHPUnit_Framework_TestCase
         date_default_timezone_set('UTC');
         \Locale::setDefault("en_EN");
     }
-    
+
     protected function getExtension()
     {
         return new DateExtension();
@@ -32,13 +32,13 @@ class DateExtensionTest extends \PHPUnit_Framework_TestCase
             ['9/20/15', "20-09-15", "{{ '20-09-2015'|localdate('short') }}"],
             ['Sunday, September 20, 2015', "zondag 20 september 2015", "{{ '20-09-2015'|localdate('full') }}"],
             ['20|09|2015', "20|09|2015", "{{ '20-09-2015'|localdate('dd|MM|yyyy') }}"],
-            
+
             ['11:14 PM', "23:14", "{{ '23:14:12'|localtime }}"],
             ['11:14:12 PM GMT', "23:14:12 GMT", "{{ '23:14:12'|localtime('long') }}"],
             ['11:14 PM', "23:14", "{{ '23:14:12'|localtime('short') }}"],
             ['11:14:12 PM GMT', "23:14:12 GMT", "{{ '23:14:12'|localtime('full') }}"],
             ['23|14|12', "23|14|12", "{{ '23:14:12'|localtime('HH|mm|ss') }}"],
-            
+
             // NOTE: a `replace` is used to remove the comma, which seems to be inconsistant accross environments.
             ['9/20/2015 11:14 PM', '20-09-2015 23:14', "{{ '20-09-2015 23:14:12'|localdatetime|replace({',': ''}) }}"],
             ['20|23', '20|23', "{{ '20-09-2015 23:14:12'|localdatetime('dd|HH') }}"],
@@ -54,10 +54,10 @@ class DateExtensionTest extends \PHPUnit_Framework_TestCase
             ]
         ];
     }
-    
+
     /**
      * @dataProvider localDateTimeProvider
-     * 
+     *
      * @param string $en
      * @param string $nl
      * @param string $template
@@ -67,13 +67,13 @@ class DateExtensionTest extends \PHPUnit_Framework_TestCase
         if (!\Locale::setDefault("en_EN")) {
             return $this->markAsSkipped("Unable to set locale to 'en_EN'");
         }
-        
+
         $this->assertRender($en, $template);
     }
-    
+
     /**
      * @dataProvider localDateTimeProvider
-     * 
+     *
      * @param string $en
      * @param string $nl
      * @param string $template
@@ -83,12 +83,12 @@ class DateExtensionTest extends \PHPUnit_Framework_TestCase
         if (!\Locale::setDefault("nl_NL")) {
             return $this->markAsSkipped("Unable to set locale to 'nl_NL'");
         }
-        
+
         $this->assertRender($nl, $template);
-        
+
     }
-    
-    
+
+
     public function durationProvider()
     {
         return [
@@ -98,21 +98,21 @@ class DateExtensionTest extends \PHPUnit_Framework_TestCase
             ['2d 3h 17m 31s', "{{ 184651|duration }}"],
             ['3w 2d 3h 17m 31s', "{{ 1999051|duration }}"],
             ['1y 3w 2d 3h 17m 31s', "{{ 33448651|duration }}"],
-            
+
             ['17 minute(s)', "{{ 1051|duration([null, ' minute(s)', ' hour(s)', ' day(s)']) }}"],
             ['3 hour(s)', "{{ 11851|duration([null, null, ' hour(s)']) }}"],
             ['2 day(s)', "{{ 184651|duration([null, null, null, ' day(s)']) }}"],
             ['3 week(s)', "{{ 1999051|duration([null, null, null, null, ' week(s)']) }}"],
             ['1 year(s)', "{{ 33448651|duration([null, null, null, null, null, ' year(s)']) }}"],
-            
+
             ['3u:17m', "{{ 11851|duration([null, 'm', 'u'], ':') }}"],
             ['3:17h', "{{ 11851|duration([null, '', ''], ':') }}h"],
         ];
     }
-    
+
     /**
      * @dataProvider durationProvider
-     * 
+     *
      * @param string $expect
      * @param string $template
      */
@@ -120,22 +120,22 @@ class DateExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertRender($expect, $template);
     }
-    
-    
+
+
     public function ageProvider()
     {
         $time = time() - (((32 * 365) + 100) * 24 * 3600);
         $date = date('Y-m-d', $time);
-        
+
         return [
             ['32', "{{ $time|age }}"],
             ['32', "{{ '$date'|age }}"]
         ];
     }
-    
+
     /**
      * @dataProvider ageProvider
-     * 
+     *
      * @param string $expect
      * @param string $template
      */
@@ -143,8 +143,8 @@ class DateExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertRender($expect, $template);
     }
-    
-    
+
+
     public function filterProvider()
     {
         return [
@@ -155,14 +155,14 @@ class DateExtensionTest extends \PHPUnit_Framework_TestCase
             ['age']
         ];
     }
-    
+
     /**
      * @dataProvider filterProvider
-     * 
+     *
      * @param string $filter
      */
     public function testWithNull($filter)
     {
         $this->assertRender('-', '{{ null|' . $filter . '("//")|default("-") }}');
-    }    
+    }
 }

--- a/tests/PcreExtensionTest.php
+++ b/tests/PcreExtensionTest.php
@@ -11,29 +11,29 @@ use Jasny\Twig\TestHelper;
 class PcreExtensionTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
-    
+
     protected function getExtension()
     {
         return new PcreExtension();
     }
-    
-    
+
+
     public function testGetName()
     {
         $this->assertEquals('jasny/pcre', $this->getExtension()->getName());
     }
-    
+
 
     public function testQuote()
     {
         $this->assertRender('foo\(\)', '{{ "foo()"|preg_quote }}');
     }
-    
+
     public function testQuoteDelimiter()
     {
         $this->assertRender('foo\@bar', '{{ "foo@bar"|preg_quote("@") }}');
     }
-    
+
     public function testPregMatch()
     {
         $this->assertRender('YES', '{% if "foo"|preg_match("/oo/") %}YES{% else %}NO{% endif %}');
@@ -45,36 +45,36 @@ class PcreExtensionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Twig_Error_Runtime
+     * @expectedException \Twig\Error\RuntimeError
      */
     public function testPregMatchError()
     {
         $this->render('{% if "fod"|preg_match("/o//o/") %}YES{% else %}NO{% endif %}');
     }
-    
-    
+
+
     public function testPregGet()
     {
         $this->assertRender('d', '{{ "food"|preg_get("/oo(.)/", 1) }}');
     }
-    
+
     public function testPregGetDefault()
     {
         $this->assertRender('ood', '{{ "food"|preg_get("/oo(.)/") }}');
     }
-    
-    
+
+
     public function testPregGetAll()
     {
         $this->assertRender('d|t|m', '{{ "food woot should doom"|preg_get_all("/oo(.)/", 1)|join("|") }}');
     }
-    
+
     public function testPregGetAllDefault()
     {
         $this->assertRender('ood|oot|oom', '{{ "food woot doom"|preg_get_all("/oo(.)/")|join("|") }}');
     }
-    
-    
+
+
     public function testPregGrep()
     {
         $this->assertRender(
@@ -82,7 +82,7 @@ class PcreExtensionTest extends \PHPUnit_Framework_TestCase
             '{{ ["hello", "sweet", "world", "how", "are", "you"]|preg_grep("/o./")|join("|") }}'
         );
     }
-    
+
     public function testPregGrepInvert()
     {
         $this->assertRender(
@@ -90,8 +90,8 @@ class PcreExtensionTest extends \PHPUnit_Framework_TestCase
             '{{ ["hello", "sweet", "world", "how", "are", "you"]|preg_grep("/o./", "invert")|join("|") }}'
         );
     }
-    
-    
+
+
     public function testReplace()
     {
         $this->assertRender(
@@ -99,7 +99,7 @@ class PcreExtensionTest extends \PHPUnit_Framework_TestCase
             '{{ "the quick brown fox jumped over the lazy dog"|preg_replace("/o(\\\\w)/", "a$1e") }}'
         );
     }
-    
+
     public function testReplaceLimit()
     {
         $this->assertRender(
@@ -107,7 +107,7 @@ class PcreExtensionTest extends \PHPUnit_Framework_TestCase
             '{{ "the quick brown fox jumped over the lazy dog"|preg_replace("/o(\\\\w)/", "a$1e", 2) }}'
         );
     }
-    
+
     public function testReplaceWithArray()
     {
         $this->assertRender(
@@ -115,16 +115,16 @@ class PcreExtensionTest extends \PHPUnit_Framework_TestCase
             '{{ ["hello", "sweet", "world", "how", "are", "you"]|preg_replace("/o(.)/", "a$1e")|join("|") }}'
         );
     }
-    
+
     /**
-     * @expectedException Twig_Error_Runtime
+     * @expectedException Twig\Error\RuntimeError
      */
     public function testReplaceAssertNoEval()
     {
         $this->render('{{ "foo"|preg_replace("/o/ei", "strtoupper") }}');
     }
-    
-    
+
+
     public function testFilter()
     {
         $this->assertRender(
@@ -132,16 +132,16 @@ class PcreExtensionTest extends \PHPUnit_Framework_TestCase
             '{{ ["hello", "sweet", "world", "how", "are", "you"]|preg_filter("/o(.)/", "a$1e")|join("|") }}'
         );
     }
-    
+
     /**
-     * @expectedException Twig_Error_Runtime
+     * @expectedException Twig\Error\RuntimeError
      */
     public function testFilterAssertNoEval()
     {
         $this->render('{{ "foo"|preg_filter("/o/ei", "strtoupper") }}');
     }
-    
-    
+
+
     public function testSplit()
     {
         $this->assertRender(
@@ -149,8 +149,8 @@ class PcreExtensionTest extends \PHPUnit_Framework_TestCase
             '{{ "the quick brown fox jumped over the lazy dog"|preg_split("/o(\\\\w)/", "a$1e")|join("|") }}'
         );
     }
-    
-    
+
+
     public function filterProvider()
     {
         return [
@@ -164,14 +164,14 @@ class PcreExtensionTest extends \PHPUnit_Framework_TestCase
             ['preg_split']
         ];
     }
-    
+
     /**
      * @dataProvider filterProvider
-     * 
+     *
      * @param string $filter
      */
     public function testWithNull($filter)
     {
         $this->assertRender('-', '{{ null|' . $filter . '("//")|default("-") }}');
-    }    
+    }
 }

--- a/tests/support/TestHelper.php
+++ b/tests/support/TestHelper.php
@@ -2,6 +2,9 @@
 
 namespace Jasny\Twig;
 
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
 /**
  * Helper methods for unit tests
  */
@@ -9,32 +12,32 @@ trait TestHelper
 {
     /**
      * Get the tested extension
-     * 
-     * @return \Twig_Extension
+     *
+     * @return \Twig\Extension\AbstractExtension;
      */
     abstract protected function getExtension();
-    
+
     /**
      * Build the Twig environment for the template
-     * 
+     *
      * @param string $template
-     * @return \Twig_Environment
+     * @return \Twig\Environment
      */
     protected function buildEnv($template)
     {
-        $loader = new \Twig_Loader_Array([
+        $loader = new ArrayLoader([
             'template' => $template,
         ]);
-        $twig = new \Twig_Environment($loader);
-        
+        $twig = new Environment($loader);
+
         $twig->addExtension($this->getExtension());
-        
+
         return $twig;
     }
-    
+
     /**
      * Render template
-     * 
+     *
      * @param string $template
      * @param array $data
      * @return string
@@ -43,13 +46,13 @@ trait TestHelper
     {
         $twig = $this->buildEnv($template);
         $result = $twig->render('template', $data);
-        
+
         return $result;
     }
-    
+
     /**
      * Render template and assert equals
-     * 
+     *
      * @param string $expected
      * @param string $template
      * @param array  $data
@@ -57,7 +60,7 @@ trait TestHelper
     protected function assertRender($expected, $template, array $data = [])
     {
         $result = $this->render($template, $data);
-        
+
         $this->assertEquals($expected, (string)$result);
     }
 }


### PR DESCRIPTION
https://github.com/WyriHaximus/TwigView/issues/219

This will need to merge into a new branch as it requires removing support for twig 1.x.

The changes are:

- Twig 3.0 dropped the class aliases.  The namespaces must be used.
- Twig 3.0 require PHP 7