### PR TITLE
Handle validation when array of patterns is passed in

### DIFF
--- a/src/PcreExtension.php
+++ b/src/PcreExtension.php
@@ -59,11 +59,15 @@ class PcreExtension extends AbstractExtension
      */
     protected function assertNoEval($pattern)
     {
-        $pos = strrpos($pattern, $pattern[0]);
-        $modifiers = substr($pattern, $pos + 1);
+        $patterns = (array)$pattern;
 
-        if (strpos($modifiers, 'e') !== false) {
-            throw new RuntimeError("Using the eval modifier for regular expressions is not allowed");
+        foreach ($patterns as $pattern) {
+            $pos       = strrpos($pattern, $pattern[0]);
+            $modifiers = substr($pattern, $pos + 1);
+
+            if (strpos($modifiers, 'e') !== false) {
+                throw new RuntimeError("Using the eval modifier for regular expressions is not allowed");
+            }
         }
     }
 

--- a/tests/PcreExtensionTest.php
+++ b/tests/PcreExtensionTest.php
@@ -116,6 +116,14 @@ class PcreExtensionTest extends TestCase
         );
     }
 
+    public function testReplaceWithArrayOfPatterns()
+    {
+        $this->assertRender(
+            '0000AAAA',
+            "{{ '1234ABCD'|preg_replace(['/\\\\d/','/[A-Z]/'],['0', 'A']) }}"
+        );
+    }
+
     public function testReplaceAssertNoEval()
     {
         $this->expectException(TwigRuntimeError::class);


### PR DESCRIPTION
This fixes https://github.com/jasny/twig-extensions/issues/21 and adds a test to ensure it works as expected.

I ran the tests locally, but one unrelated one was failing from the start, otherwise all are passing

Just for reference the failing test was

```
1) Jasny\Twig\DateExtensionTest::testLocalDateTimeNL with data set #2 ('9/20/15', '20-09-15', '{{ '20-09-2015'|localdate('short') }}')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'20-09-15'
+'20-09-2015'

```
